### PR TITLE
Fix an async / sync dispatch

### DIFF
--- a/Synopsis Analyzer/Session-related/GPULoadBalancer.m
+++ b/Synopsis Analyzer/Session-related/GPULoadBalancer.m
@@ -218,7 +218,7 @@
 
 - (void) rebuildViableDeviceListFromDevices:(NSArray<id<MTLDevice>>*)devices
 {
-    dispatch_async(self.deviceQueue, ^{
+    dispatch_sync(self.deviceQueue, ^{
         self.viableDevices = [NSMutableArray new];
         
         for (id<MTLDevice> device in devices)


### PR DESCRIPTION
This PR adds:

* GPU load balancer singleton with a job checkout / return system
* Supports eGPU device attachment and detachment
* Updates SynOp to use the GPULoadBalancer
* Updated SynopsisJobObject to accept an preferred Metal Device
* Adds 10.15 specific video toolbox encoder and decoder keys in an attempt to keep all decoding, pre processing, analysis and encoding on a specific GPU!